### PR TITLE
Fix delaunay constraint fulfillment in some edge cases

### DIFF
--- a/Assets/Scripts/DelaunayTriangulation.cs
+++ b/Assets/Scripts/DelaunayTriangulation.cs
@@ -13,7 +13,6 @@
 
 using Game.Utils.Math;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 
 namespace Game.Utils.Triangulation


### PR DESCRIPTION
In some cases you may have to go through multiple adjacent triangles when checking for the constraint. You can't assume in this case that you only need to check the adjacent triangles of the opposite triangle nor can you assume that the index of the vertex outside of the triangle is always 0.

This was causing some issues with simple shapes like a 10x10 grid.