### PR TITLE
Fix for GetTrianglesInPolygon() choosing adjacent triangles outside of the outline

### DIFF
--- a/Assets/Scripts/DelaunayTriangleSet.cs
+++ b/Assets/Scripts/DelaunayTriangleSet.cs
@@ -233,7 +233,9 @@ namespace Game.Utils.Triangulation
             for (int i = 0; i < polygonOutline.Count; ++i)
             {
                 // For every edge, it gets the inner triangle that contains such edge
-                DelaunayTriangleEdge triangleEdge = FindTriangleThatContainsEdge(polygonOutline[i], polygonOutline[(i + 1) % polygonOutline.Count]);
+                int currEdgeVertexA = polygonOutline[i];
+                int currEdgeVertexB = polygonOutline[(i + 1) % polygonOutline.Count];
+                DelaunayTriangleEdge triangleEdge = FindTriangleThatContainsEdge(currEdgeVertexA, currEdgeVertexB);
 
                 // A triangle may form a corner, with 2 consecutive outline edges. This avoids adding it twice
                 if(outputTrianglesInPolygon.Count > 0 &&
@@ -264,7 +266,9 @@ namespace Game.Utils.Triangulation
                         if ((currentTriangleEdgeVertexA == previousOutlineEdgeVertexA && currentTriangleEdgeVertexB == previousOutlineEdgeVertexB) ||
                             (currentTriangleEdgeVertexA == previousOutlineEdgeVertexB && currentTriangleEdgeVertexB == previousOutlineEdgeVertexA) ||
                             (currentTriangleEdgeVertexA == nextOutlineEdgeVertexA && currentTriangleEdgeVertexB == nextOutlineEdgeVertexB) ||
-                            (currentTriangleEdgeVertexA == nextOutlineEdgeVertexB && currentTriangleEdgeVertexB == nextOutlineEdgeVertexA))
+                            (currentTriangleEdgeVertexA == nextOutlineEdgeVertexB && currentTriangleEdgeVertexB == nextOutlineEdgeVertexA) ||
+                            (currentTriangleEdgeVertexA == currEdgeVertexA && currentTriangleEdgeVertexB == currEdgeVertexB) ||
+                            (currentTriangleEdgeVertexA == currEdgeVertexB && currentTriangleEdgeVertexB == currEdgeVertexA))
                         {
                             isAdjacentTriangleInOutline = true;
                         }


### PR DESCRIPTION
In section 5.4 "Identify all of the triangles in the polygon" from [the article about this algorithm](https://jailbrokengame.com/2023/03/30/constrained-delaunay-triangulation/#Algorithm), it says "If TA does not have an edge in the outline and it has not been added to the output list yet, then we add it to a stack". However when running the algorithm I noticed that only the previous edge and next edge's are treated as part of the outline, the current edge is never checked. This led to polygons outside of the hole being chosen whenever there was a triangle outside of the hole that used that edge, since it was being added to the adjacentTriangles stack and eventually outputTrianglesInPolygon, as there are no further checks done beyond this point.

See the image below for the edge that is not being checked, it is circled in red.

The fix in this PR is what I had to do in my project to resolve this, which is simply to check against the currEdgeVertexA and currEdgeVertexB as well as prevEdge and nextEdge. Note that I haven't tested this PR as I don't have Unity, I implemented this in my own C++ engine that uses Raylib. However given the simplicity of the change I am fairly confident it will work.

<img width="872" height="436" alt="image" src="https://github.com/user-attachments/assets/a0e125fb-a0fe-4353-8496-8b3028da3a3b" />
